### PR TITLE
force_defund should run if the discriminator is CLOSED_ACCOUNT_DISCRIMINATOR

### DIFF
--- a/programs/9-closing-accounts/secure/src/lib.rs
+++ b/programs/9-closing-accounts/secure/src/lib.rs
@@ -38,7 +38,7 @@ pub mod closing_accounts_secure {
 
         let mut discriminator = [0u8; 8];
         discriminator.copy_from_slice(&data[0..8]);
-        if discriminator == CLOSED_ACCOUNT_DISCRIMINATOR {
+        if discriminator != CLOSED_ACCOUNT_DISCRIMINATOR {
             return Err(ProgramError::InvalidAccountData);
         }
 


### PR DESCRIPTION
Closes #4 